### PR TITLE
Fix build by forcing npm legacy peer deps

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "installCommand": "npm install --legacy-peer-deps",
   "build": {
     "env": {
       "NPM_FLAGS": "--legacy-peer-deps"


### PR DESCRIPTION
## Summary
- specify `npm install --legacy-peer-deps` for Vercel

## Testing
- `npm run lint` *(fails: `next` not found due to missing deps)*


------
https://chatgpt.com/codex/tasks/task_e_686a35a526cc83229331cd34cddac4b8